### PR TITLE
ensure that made with dough uses version 1.11.* of jquery

### DIFF
--- a/bower.json.erb
+++ b/bower.json.erb
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "yeast": "git://github.com/moneyadviceservice/yeast.git#master",
-    "dough": "<%= gem_path('dough-ruby') %>"
+    "dough": "<%= gem_path('dough-ruby') %>",
+    "jquery": "1.11.*"
   }
 }


### PR DESCRIPTION
Discovered that the made with dough website was using a 2.X version of jquery which no longer supports IE8 - our sites are supposed to be functional in IE8, so therefore the dough components should also work in IE8.

Version 1.11.\* of jquery still supports IE8, so make sure that bower has a dependancy on this version.
