### PR TITLE
Adding viewport tag so page is responsive

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,8 @@
 <html>
 <head>
   <title>Made With Dough</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
   <%= stylesheet_link_tag 'dough/assets/stylesheets/basic' %>
   <%= stylesheet_link_tag 'dough/assets/stylesheets/font_files' %>
 


### PR DESCRIPTION
Small PR to make the _madewithdough.org.uk_ page scale to device size, required for responsive layouts. Hopefully this will pave the way for some much more significant enhancements to the madewithdough site.