### PR TITLE
id: 7229, comment: Update to include Social Sharing Icons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 
 GIT
   remote: git://github.com/moneyadviceservice/dough.git
-  revision: e4ab3730313a950c004c7780802a04cddcef8739
+  revision: 22e643302724d85672e44ef966b895785704411c
   specs:
-    dough-ruby (5.7.1)
+    dough-ruby (5.12.0)
       activesupport
       rails (>= 3.2)
       sass-rails (~> 4.0.0)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,9 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
+<!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
+<%# render 'dough/shared/social_sharing_icon_sprite' %>
+<!--<![endif]-->
 
 <%= yield %>
 


### PR DESCRIPTION
Ensures that Made with Dough uses the most recent version of Dough that includes the Social Sharing icons:
- Bumps version of Dough
- Adds SVG sprite